### PR TITLE
A user can search for services

### DIFF
--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -5,6 +5,7 @@ import validateUserDoNotExists from './validateUserDoNotExists';
 import validateUsersProfileExists from './validateUsersProfileExists';
 import validateServicesInput from './validateServicesInput';
 import validateToken from './validateToken';
+import validateSearchServicesUrl from './validateSearchServicesUrl';
 
 export {
   validateUserExists,
@@ -13,5 +14,6 @@ export {
   validateUserDoNotExists,
   validateUsersProfileExists,
   validateServicesInput,
-  validateToken
+  validateToken,
+  validateSearchServicesUrl
 };

--- a/middlewares/validateSearchServicesUrl.js
+++ b/middlewares/validateSearchServicesUrl.js
@@ -1,0 +1,19 @@
+// Helpers
+import { StatusResponse } from '../helpers';
+
+// This function validates that a url matches specified url
+const validateSearchServicesUrl = (req, res, next) => {
+  const { query } = req.query;
+  if (query === undefined) {
+    StatusResponse.badRequest(res, {
+      status: 400,
+      data: {
+        message: 'Invalid url, url should be like services/search?query=',
+      }
+    });
+  } else {
+    return next();
+  }
+};
+
+export default validateSearchServicesUrl;

--- a/routes/services.js
+++ b/routes/services.js
@@ -1,8 +1,11 @@
 import express from 'express';
 import { Services } from '../controllers';
 import { validateServicesInput, validateToken } from '../middlewares';
+import validateSearchServicesUrl from '../middlewares/validateSearchServicesUrl';
 
 const router = express.Router();
+
+router.get('/search', validateSearchServicesUrl, Services.search);
 
 router.post('/:username', validateServicesInput, validateToken, Services.create);
 

--- a/test/services.js
+++ b/test/services.js
@@ -194,4 +194,37 @@ describe('Errnd Services Test Suite', () => {
       res.body.data.message.should.equal('Runner not found');
     });
   });
+
+  // ==== Search for services ==== //
+  describe(' GET services/search?query=Computer Science - Retrieve all services matching specified search params', () => {
+    it('should return status code 200 on retrieving all services matching specified search params', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/services/search?query=Computer Science');
+      res.status.should.equal(200);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('Searched services returned successfully');
+    });
+
+    it('should return status code 404 on no services matching specified search params', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/services/search?query=nmmmdmkrkrkrkememekekmemeedsksksmdjfjkftjkf394944848848usnsndsnn');
+      res.status.should.equal(404);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('No services matching the searched parameter');
+    });
+
+    it('should return status code 400 if invalid url is provided', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/services/search?queryyyyyyyeyeyehsb=Computer Science');
+      res.status.should.equal(400);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('Invalid url, url should be like services/search?query=');
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
It enables a user search for services
#### Description of Task to be completed
- add functionality to enable a user search for services
#### How should this be manually tested?
* Clone the repo
* Execute the following commands on your terminal

> * git checkout `ft-search-for-services`.
> * npm install
> * npm run start:dev
> * using postman navigate to **GET** `http://localhost:3005/api/v1/services/search?Computer Science`.
> * click send


#### Any background context you want to provide?
Previously, there was no way to retrieve search for services

#### Screenshots (if appropriate)
N/A
