### PR TITLE
A user can bookmark services

### DIFF
--- a/controllers/Bookmarks.js
+++ b/controllers/Bookmarks.js
@@ -1,0 +1,255 @@
+import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
+import { Op } from 'sequelize';
+import model from '../models';
+import { StatusResponse } from '../helpers';
+
+dotenv.config();
+
+const {
+  bookmarks, users, services
+} = model;
+
+/**
+ * @description - This class is all about users bookmarked services
+ * @param {object} req
+ * @param {object} res
+ * @returns {class} Bookmarked Services
+ */
+class Bookmarks {
+  /**
+   * @description - This method takes care of helping a user bookmark services
+   * @param {object} req - request object
+   * @param {object} res - response object
+   * @returns {object} user's bookmarked services
+   */
+  static async create(req, res) {
+    const { title } = req.body;
+    const { serviceId } = req.params;
+    const token = req.headers.authorization;
+
+    try {
+      const decoded = jwt.verify(token, process.env.SECRET_KEY);
+
+      await bookmarks.create({
+        title,
+        userId: decoded.userId,
+        serviceId
+      });
+
+      const refinedBookmarkedServices = await bookmarks.findOne({
+        where: {
+          userId: decoded.userId,
+          serviceId
+        },
+        include: [{
+          model: services,
+          as: 'service',
+          attributes: { exclude: ['id', 'userId'] }
+        }, {
+          model: users,
+          as: 'user',
+          attributes: { exclude: ['id', 'password', 'createdAt', 'updatedAt', 'role'] }
+        }],
+        order: [['id', 'DESC']]
+      });
+
+      const refinedServices = await [refinedBookmarkedServices.service].map((eachService) => {
+        const parsedOptions = JSON.parse(eachService.dataValues.packageoptions);
+        return Object.assign(eachService.dataValues, {
+          packageoptions: parsedOptions
+        });
+      });
+
+      StatusResponse.created(res, {
+        status: 201,
+        data: {
+          message: 'Services bookmarked successfully',
+          bookmark: Object.assign(refinedBookmarkedServices, {
+            service: refinedServices
+          })
+        }
+      });
+    } catch (error) {
+      StatusResponse.unauthorized(res, {
+        status: 401,
+        data: {
+          error: 'Unauthorized, user not authenticated'
+        }
+      });
+    }
+  }
+
+  /**
+   * @description - This method takes care of helping a user search
+   * for bookmarked services based on search parameters
+   * @param {object} req - request object
+   * @param {object} res - response object
+   * @returns {object} user's bookmarked services
+   */
+  static async search(req, res) {
+    const { query } = req.query;
+    const token = req.headers.authorization;
+
+    try {
+      const decoded = jwt.verify(token, process.env.SECRET_KEY);
+      const bookmarkedServices = await bookmarks.findAndCountAll({
+        where: {
+          title: { [Op.iLike]: `%${query}%` },
+          userId: decoded.userId,
+        },
+        include: [{
+          model: services,
+          as: 'service',
+          attributes: { exclude: ['id', 'userId'] }
+        }, {
+          model: users,
+          as: 'user',
+          attributes: { exclude: ['id', 'password', 'createdAt', 'updatedAt', 'role'] }
+        }],
+        order: [['id', 'DESC']]
+      });
+
+      await bookmarkedServices.rows.map((eachService) => {
+        const parsedOptions = JSON.parse(eachService.dataValues.service.packageoptions);
+        return Object.assign(eachService.dataValues.service, {
+          packageoptions: parsedOptions
+        });
+      });
+
+      if (bookmarkedServices.count > 0) {
+        StatusResponse.success(res, {
+          status: 200,
+          data: {
+            message: 'Bookmarked services returned successfully',
+            bookmark: bookmarkedServices
+          }
+        });
+      } else {
+        StatusResponse.notfound(res, {
+          status: 404,
+          data: {
+            message: 'No bookmarked services found',
+            bookmark: {}
+          }
+        });
+      }
+    } catch (error) {
+      StatusResponse.unauthorized(res, {
+        status: 401,
+        data: {
+          error: 'Unauthorized, user not authenticated'
+        }
+      });
+    }
+  }
+
+  /**
+   * @description - This method takes care of helping a user retrieve all his bookmarked services
+   * @param {object} req - request object
+   * @param {object} res - response object
+   * @returns {object} user's bookmarked services
+   */
+  static async retrieve(req, res) {
+    const token = req.headers.authorization;
+
+    try {
+      const decoded = jwt.verify(token, process.env.SECRET_KEY);
+      const bookmarkedServices = await bookmarks.findAndCountAll({
+        where: {
+          userId: decoded.userId
+        },
+        include: [{
+          model: services,
+          as: 'service',
+          attributes: { exclude: ['id', 'userId'] }
+        }, {
+          model: users,
+          as: 'user',
+          attributes: { exclude: ['id', 'password', 'createdAt', 'updatedAt', 'role'] }
+        }],
+        order: [['id', 'DESC']]
+      });
+
+      await bookmarkedServices.rows.map((eachService) => {
+        const parsedOptions = JSON.parse(eachService.dataValues.service.packageoptions);
+        return Object.assign(eachService.dataValues.service, {
+          packageoptions: parsedOptions
+        });
+      });
+
+
+      if (bookmarkedServices.count > 0) {
+        StatusResponse.success(res, {
+          status: 200,
+          data: {
+            message: 'Bookmarked services returned successfully',
+            bookmark: bookmarkedServices
+          }
+        });
+      } else {
+        StatusResponse.notfound(res, {
+          status: 404,
+          data: {
+            message: 'No bookmarked services found',
+            bookmark: {}
+          }
+        });
+      }
+    } catch (error) {
+      StatusResponse.unauthorized(res, {
+        status: 401,
+        data: {
+          error: 'Unauthorized, user not authenticated'
+        }
+      });
+    }
+  }
+
+  /**
+   * @description - This method takes care of helping a user delete his bookmarked services
+   * @param {object} req - request object
+   * @param {object} res - response object
+   * @returns {void}
+   */
+  static async delete(req, res) {
+    const token = req.headers.authorization;
+    const { serviceId } = req.params;
+
+    try {
+      const decoded = jwt.verify(token, process.env.SECRET_KEY);
+      const bookmarkedServices = await bookmarks.findOne({
+        where: {
+          serviceId,
+          userId: decoded.userId
+        }
+      });
+      if (bookmarkedServices) {
+        await bookmarkedServices.destroy({});
+        StatusResponse.success(res, {
+          status: 200,
+          data: {
+            message: 'Bookmarked services deleted successfully'
+          }
+        });
+      } else {
+        StatusResponse.notfound(res, {
+          status: 404,
+          data: {
+            message: 'No bookmarked services found',
+            bookmark: {}
+          }
+        });
+      }
+    } catch (error) {
+      StatusResponse.unauthorized(res, {
+        status: 401,
+        data: {
+          error: 'Unauthorized, user not authenticated'
+        }
+      });
+    }
+  }
+}
+
+export default Bookmarks;

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -2,10 +2,12 @@ import Auth from './Auth';
 import Profile from './Profile';
 import Roles from './Roles';
 import Services from './Services';
+import Bookmarks from './Bookmarks';
 
 export {
   Auth,
   Profile,
   Roles,
-  Services
+  Services,
+  Bookmarks
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ import {
   auth,
   profile,
   roles,
-  services
+  services,
+  bookmarks
 } from './routes';
 
 const PORT = process.env.PORT || 3005;
@@ -28,6 +29,7 @@ app.use('/api/v1/auth', auth);
 app.use('/api/v1/profile', profile);
 app.use('/api/v1/role', roles);
 app.use('/api/v1/services', services);
+app.use('/api/v1/bookmarks', bookmarks);
 
 // Default to here on home route
 app.get('/', (req, res) => StatusResponse.success(res, {

--- a/middlewares/validateSearchServicesUrl.js
+++ b/middlewares/validateSearchServicesUrl.js
@@ -8,7 +8,7 @@ const validateSearchServicesUrl = (req, res, next) => {
     StatusResponse.badRequest(res, {
       status: 400,
       data: {
-        message: 'Invalid url, url should be like services/search?query=',
+        message: 'Invalid url, url should be like /search?query=',
       }
     });
   } else {

--- a/migrations/20190615165959-create-bookmarks.js
+++ b/migrations/20190615165959-create-bookmarks.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-unused-vars */
+export function up(queryInterface, Sequelize) {
+  return queryInterface.createTable('bookmarks', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    title: {
+      type: Sequelize.STRING
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'users',
+        key: 'id'
+      },
+    },
+    serviceId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'services',
+        key: 'id'
+      },
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  });
+}
+export function down(queryInterface, Sequelize) { return queryInterface.dropTable('bookmarks'); }

--- a/models/bookmarks.js
+++ b/models/bookmarks.js
@@ -1,0 +1,17 @@
+export default (sequelize, DataTypes) => {
+  const Bookmarks = sequelize.define('bookmarks', {
+    title: DataTypes.STRING
+  }, {});
+  Bookmarks.associate = (models) => {
+    // associations can be defined here
+    Bookmarks.belongsTo(models.users, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE',
+    });
+    Bookmarks.belongsTo(models.services, {
+      foreignKey: 'serviceId',
+      onDelete: 'CASCADE',
+    });
+  };
+  return Bookmarks;
+};

--- a/models/services.js
+++ b/models/services.js
@@ -15,6 +15,11 @@ export default (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
       as: 'user'
     });
+    Services.hasMany(models.bookmarks, {
+      foreignKey: 'serviceId',
+      onDelete: 'CASCADE',
+      as: 'bookmarks'
+    });
   };
   return Services;
 };

--- a/models/users.js
+++ b/models/users.js
@@ -15,6 +15,11 @@ export default (sequelize, DataTypes) => {
       foreignKey: 'userId',
       as: 'services'
     });
+    Users.hasMany(models.bookmarks, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE',
+      as: 'bookmarks'
+    });
   };
   return Users;
 };

--- a/routes/bookmarks.js
+++ b/routes/bookmarks.js
@@ -1,0 +1,15 @@
+import express from 'express';
+import Bookmarks from '../controllers/Bookmarks';
+import { validateToken, validateSearchServicesUrl } from '../middlewares';
+
+const router = express.Router();
+
+router.get('/search', validateToken, validateSearchServicesUrl, Bookmarks.search);
+
+router.post('/create/:serviceId', validateToken, Bookmarks.create);
+
+router.delete('/remove/:serviceId', validateToken, Bookmarks.delete);
+
+router.get('/', validateToken, Bookmarks.retrieve);
+
+export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,10 +2,12 @@ import auth from './auth';
 import profile from './profile';
 import roles from './roles';
 import services from './services';
+import bookmarks from './bookmarks';
 
 export {
   auth,
   profile,
   roles,
-  services
+  services,
+  bookmarks
 };

--- a/test/bookmarks.js
+++ b/test/bookmarks.js
@@ -1,0 +1,208 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+
+chai.use(chaiHttp);
+chai.should();
+
+const newBookmark = {
+  title: 'Develop your web app',
+};
+
+const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RydW5uZXIxQGVycm5kLmNvbSIsInVzZXJJZCI6MSwicm9sZSI6InJ1bm5lciIsInVzZXJuYW1lIjoidGVzdHJ1bm5lcjEiLCJpYXQiOjE1NTkyNDkwODksImV4cCI6MTk5OTk5OTk5OX0.tYs-XsFksexcgSjke1dXoInEi_ZrgU6OKuQD_0tI-ew';
+const invalidToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RydW5uZXIxQGVycm5kLmNvbSIsInVzZXJJZCI6MSwicm9sZSI6InJ1bm5lciIsInVzZXJuYW1lIjoidGVzdHJ1bm5lcjEiLCJpYXQiOjE1NTkyNDkwODksImV4cCI6MTk5OTk5OTk5OX0.qVzoEX0d1YVTokAnpylou8gtbE7a5aPWl-NEUkNO7sE';
+const noToken = '';
+const customerWithNoBookmarkToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImN1c3RvbWVyMkBlcnJuZC5jb20iLCJ1c2VySWQiOjQsInJvbGUiOiJjdXN0b21lciIsInVzZXJuYW1lIjoiY3VzdG9tZXIyIiwiaWF0IjoxNTYwNjg1Mjc4LCJleHAiOjE1NjA3NzE2Nzh9.1m6Q81iIqbzUhNRvScUaMfEAG5Sp4KdvnYJO8r4EZFY';
+
+describe('Errnd Bookmarks Test Suite', () => {
+  // ==== Create a new bookmark ==== //
+  describe(' POST bookmarks/create - Create a new bookmark', () => {
+    it('should return status code 201 on creating a new bookmark', async () => {
+      const res = await chai.request(app)
+        .post('/api/v1/bookmarks/create/1')
+        .set('authorization', token)
+        .send(newBookmark);
+      res.status.should.equal(201);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('Services bookmarked successfully');
+    });
+
+    it('should return status code 401 if token is invalid', async () => {
+      const res = await chai.request(app)
+        .post('/api/v1/bookmarks/create/1')
+        .set('authorization', invalidToken)
+        .send(newBookmark);
+      res.status.should.equal(401);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.error.should.equal('Unauthorized, user not authenticated');
+    });
+
+    it('should return status code 400 if no token is provided', async () => {
+      const res = await chai.request(app)
+        .post('/api/v1/bookmarks/create/1')
+        .set('authorization', noToken)
+        .send(newBookmark);
+      res.status.should.equal(400);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.error.token.should.equal('No token provided, please provide one');
+    });
+  });
+
+  // ==== Retrieve all bookmarks by a user ==== //
+  describe(' GET bookmarks/ - Retrieve all bookmarks by a user', () => {
+    it('should return status code 200 it can retrieve all bookmarks by a user', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks')
+        .set('authorization', token);
+      res.status.should.equal(200);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('Bookmarked services returned successfully');
+    });
+
+    it('should return status code 401 if token is invalid', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks')
+        .set('authorization', invalidToken);
+      res.status.should.equal(401);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.error.should.equal('Unauthorized, user not authenticated');
+    });
+
+    it('should return status code 404 on bookmark not found', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks')
+        .set('authorization', customerWithNoBookmarkToken);
+      res.status.should.equal(404);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('No bookmarked services found');
+    });
+
+    it('should return status code 400 if no token is provided', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks')
+        .set('authorization', noToken);
+      res.status.should.equal(400);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.error.token.should.equal('No token provided, please provide one');
+    });
+  });
+
+  // ==== Search for bookmarks ==== //
+  describe(' GET bookmarks/search?query=Develop your web app - Retrieve all bookmarks matching specified search params', () => {
+    it('should return status code 200 on retrieving all bookmarks matching specified search params', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks/search?query=Develop your web app')
+        .set('authorization', token);
+      res.status.should.equal(200);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('Bookmarked services returned successfully');
+    });
+
+    it('should return status code 401 if token is invalid', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks/search?query=Develop your web app')
+        .set('authorization', invalidToken);
+      res.status.should.equal(401);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.error.should.equal('Unauthorized, user not authenticated');
+    });
+
+    it('should return status code 404 on bookmark not found', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks/search?query=xvvvvvvvzzzzzzzzqqqqqqqqq')
+        .set('authorization', token);
+      res.status.should.equal(404);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('No bookmarked services found');
+    });
+
+    it('should return status code 400 if no token is provided', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks/search?query=Develop your web app')
+        .set('authorization', noToken);
+      res.status.should.equal(400);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.error.token.should.equal('No token provided, please provide one');
+    });
+
+    it('should return status code 400 if invalid url is provided', async () => {
+      const res = await chai.request(app)
+        .get('/api/v1/bookmarks/search?queryyyyyyyeyeyehsb=Develop your web app')
+        .set('authorization', token);
+      res.status.should.equal(400);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('Invalid url, url should be like /search?query=');
+    });
+  });
+
+  // ==== Delete an existing bookmark ==== //
+  describe(' DELETE bookmarks/remove/1 - Delete an existing bookmark', () => {
+    it('should return status code 400 if no token is provided', async () => {
+      const res = await chai.request(app)
+        .delete('/api/v1/bookmarks/remove/1')
+        .set('authorization', noToken);
+      res.status.should.equal(400);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.error.token.should.equal('No token provided, please provide one');
+    });
+
+    it('should return status code 401 if token is invalid', async () => {
+      const res = await chai.request(app)
+        .delete('/api/v1/bookmarks/remove/1')
+        .set('authorization', invalidToken);
+      res.status.should.equal(401);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.error.should.equal('Unauthorized, user not authenticated');
+    });
+
+    it('should return status code 404 on bookmark not found', async () => {
+      const res = await chai.request(app)
+        .delete('/api/v1/bookmarks/remove/0')
+        .set('authorization', token);
+      res.status.should.equal(404);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('No bookmarked services found');
+    });
+
+    it('should return status code 200 on deleting an existing bookmark', async () => {
+      const res = await chai.request(app)
+        .delete('/api/v1/bookmarks/remove/1')
+        .set('authorization', token);
+      res.status.should.equal(200);
+      res.body.should.be.a('object');
+      res.body.should.have.property('data');
+      res.body.should.have.property('status');
+      res.body.data.message.should.equal('Bookmarked services deleted successfully');
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -3,3 +3,4 @@ import './user';
 import './profile';
 import './role';
 import './services';
+import './bookmarks';

--- a/test/services.js
+++ b/test/services.js
@@ -224,7 +224,7 @@ describe('Errnd Services Test Suite', () => {
       res.body.should.be.a('object');
       res.body.should.have.property('data');
       res.body.should.have.property('status');
-      res.body.data.message.should.equal('Invalid url, url should be like services/search?query=');
+      res.body.data.message.should.equal('Invalid url, url should be like /search?query=');
     });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
It enables a user can bookmark services
#### Description of Task to be completed
- add functionality to enable a user bookmark services
- add functionality to enable a retrieve bookmarked services
- add functionality to enable a user search for bookmarked services
- add functionality to enable a user delete bookmark services
#### How should this be manually tested?
* Clone the repo
* Execute the following commands on your terminal

> * git checkout `ft-user-bookmark-services`.
> * npm install
> * npm run start:dev
> * using postman navigate to **POST** `http://localhost:3005/api/v1/bookmarks/create`.
> * add this JSON to then { "title": develop your web app"}
> * click send


#### Any background context you want to provide?
Previously, there was no way a user can bookmark services

#### Screenshots (if appropriate)
N/A
